### PR TITLE
Avoid returning EXIT_SUCCESS when boostrap failed

### DIFF
--- a/bootstrap
+++ b/bootstrap
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/sh -e
 
 if [ -d m4 ]; then
   OPTIONS="-I m4"


### PR DESCRIPTION
I got stung by that in while compiling ocaml-ffmpeg. Some tools were not installed but `./boostrap` didn't fail as expected.